### PR TITLE
Remove unsupported platforms from ext.manifest

### DIFF
--- a/openssl/ext.manifest
+++ b/openssl/ext.manifest
@@ -1,14 +1,7 @@
 name: "OpenSSL"
 
 platforms:
-    x86-osx:
-        context:
-            frameworks: []
-            flags:      ["-std=c++11", "-stdlib=libc++"]
-            linkFlags:  ["-stdlib=libc++"]
-            libs:       ["c++"]
-
-    x86_64-osx:
+    osx:
         context:
             frameworks: []
             flags:      ["-std=c++11", "-stdlib=libc++"]


### PR DESCRIPTION
https://github.com/defold/extender/issues/674

Defold update build server.
Unsupported platforms should be removed from manifest